### PR TITLE
Update fsx.tf

### DIFF
--- a/terraform/fsx.tf
+++ b/terraform/fsx.tf
@@ -1,6 +1,10 @@
 
 resource "random_string" "fsx_password" {
   length           = 8
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
   number           = true
   special          = true
   override_special = "!"


### PR DESCRIPTION
The minimum password requirements cannot be met without adding minimum character counts. Occasionally the script fails without these.

*Issue #, if available: https://github.com/aws-samples/amazon-eks-fsx-for-netapp-ontap/issues/2  *

*Description of changes: minimum character counts for password string*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
