### PR TITLE
Remove deprecated terraform Template Provider

### DIFF
--- a/terraform/eks-cluster.tf
+++ b/terraform/eks-cluster.tf
@@ -30,22 +30,18 @@ module "eks" {
 
       enable_bootstrap_user_data = true
 
-      post_bootstrap_user_data = data.template_cloudinit_config.cloudinit.rendered
+      pre_bootstrap_user_data = data.cloudinit_config.cloudinit.rendered
     }
   }
 }
 
-data "template_file" "iscsi_script" {
-  template = file("scripts/iscsi.sh")
-}
-
-data "template_cloudinit_config" "cloudinit" {
+data "cloudinit_config" "cloudinit" {
   gzip          = false
   base64_encode = false
 
   part {
     content_type = "text/x-shellscript"
-    content      = data.template_file.iscsi_script.rendered
+    content      = file("scripts/iscsi.sh")
   }
 }
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -22,7 +22,7 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.1.0"
     }
-    template = {
+    cloudinit = {
       source  = "hashicorp/cloudinit"
       version = "~> 2.2.0"
     }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = "~> 3.1.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = ">=2.7.1"
     }
     aws = {
@@ -23,7 +23,7 @@ terraform {
       version = "~> 3.1.0"
     }
     template = {
-      source  = "hashicorp/template"
+      source  = "hashicorp/cloudinit"
       version = "~> 2.2.0"
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
#5 

*Description of changes:*
Replaced deprecated [template](https://registry.terraform.io/providers/hashicorp/template/latest/docs) provider and [template_cloudinit_config](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) provider.

In addition, post_bootstrap_user_data does [not appear to be supported](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/user_data.md#eks-managed-node-group) if a custom AMI is not specified for a managed node group. I replaced it with pre_bootstrap_user_data because it was actually run before bootstrap.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
